### PR TITLE
Optimize dashboard meal loading

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,11 +7,13 @@ import UserDashboard from "@/components/app/UserDashboard";
 import { useAppStore } from '@/store/useAppStore';
 import { useUser } from '@/hooks/useUser';
 import AuthGuard from '@/components/app/AuthGuard';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function DashboardPage() {
   const router = useRouter();
   const checkAndResetDaily = useAppStore((state) => state.checkAndResetDaily);
   const { user } = useUser();
+  const queryClient = useQueryClient();
   
   // Check if we need to reset daily nutrition counters
   useEffect(() => {
@@ -28,11 +30,8 @@ export default function DashboardPage() {
         // Use React Query invalidation instead of full page reload
         const refreshData = async () => {
           try {
-            const { queryClient } = await import('@/providers/QueryProvider');
-            if (queryClient) {
-              queryClient.invalidateQueries({ queryKey: ['meals'] });
-              queryClient.invalidateQueries({ queryKey: ['user'] });
-            }
+            queryClient.invalidateQueries({ queryKey: ['meals'] });
+            queryClient.invalidateQueries({ queryKey: ['user'] });
             checkAndResetDaily();
           } catch (error) {
             if (process.env.NODE_ENV === 'development') {
@@ -51,7 +50,7 @@ export default function DashboardPage() {
     };
     
     prefetchRoutes().catch(console.error);
-  }, [router, checkAndResetDaily]);
+  }, [router, checkAndResetDaily, queryClient]);
 
   return (
     <AuthGuard>

--- a/src/components/app/FoodDescriptionAnalyzer.tsx
+++ b/src/components/app/FoodDescriptionAnalyzer.tsx
@@ -9,7 +9,6 @@ import { Loader2, Send } from 'lucide-react';
 import { useAnalyzeImage } from '@/hooks/useAnalyzeImage';
 import NutritionDisplay from './NutritionDisplay';
 import { useQueryClient } from '@tanstack/react-query';
-import { useAuth } from '@/hooks/useAuth';
 
 export default function FoodDescriptionAnalyzer() {
   const [description, setDescription] = useState<string>('');
@@ -18,7 +17,6 @@ export default function FoodDescriptionAnalyzer() {
   const setError = useState<Error | null>(null)[1];
   const analyzeImageMutation = useAnalyzeImage();
   const queryClient = useQueryClient();
-  const { user } = useAuth();
   
   const analyzeDescription = async () => {
     if (!description.trim()) return;
@@ -36,12 +34,6 @@ export default function FoodDescriptionAnalyzer() {
         onSuccess: async () => {
           // Invalidate any queries that fetch meals to force a refresh
           queryClient.invalidateQueries({ queryKey: ['meals'] });
-          
-          // Directly fetch meals to ensure immediate UI update
-          if (user?.id) {
-            queryClient.fetchQuery({ queryKey: ['meals', user.id] })
-              .catch(err => console.error('Error fetching meals after analysis:', err));
-          }
         }
       });
     } catch (err) {

--- a/src/components/app/ManualFoodEntry.tsx
+++ b/src/components/app/ManualFoodEntry.tsx
@@ -11,7 +11,7 @@ import { useAppStore } from '@/store/useAppStore';
 import { useQueryClient } from '@tanstack/react-query';
 
 export default function ManualFoodEntry() {
-  const { addMeal } = useMeals();
+  const { addMeal } = useMeals(undefined, { skip: true });
   const refreshAll = useAppStore((state) => state.refreshAll);
   const queryClient = useQueryClient();
   
@@ -65,13 +65,6 @@ export default function ManualFoodEntry() {
       
       // Invalidate any queries that fetch meals to force a refresh
       queryClient.invalidateQueries({ queryKey: ['meals'] });
-      
-      // Directly fetch meals to ensure immediate UI update
-      const { user } = await import('@/hooks/useAuth').then(m => m.useAuth());
-      if (user?.id) {
-        queryClient.fetchQuery({ queryKey: ['meals', user.id] })
-          .catch(err => console.error('Error fetching meals after add:', err));
-      }
       
       // Refresh the app state as a fallback
       await refreshAll();

--- a/src/components/app/NutritionDashboard.tsx
+++ b/src/components/app/NutritionDashboard.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader } from '../ui/card';
 import NutritionCircles from './NutritionCircles';
 import DateNavigation from './DateNavigation';
 import { useMeals } from '@/hooks/useMeals';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface NutritionDashboardProps {
   selectedDate?: Date;
@@ -36,7 +37,8 @@ export default function NutritionDashboard({
   };
 
   // Using useMeals hook to get real-time nutrition data
-  const { dailyTotals, loading: mealsLoading } = useMeals();
+  const queryClient = useQueryClient();
+  const { dailyTotals, loading: mealsLoading } = useMeals(selectedDate);
   
   // Use user's custom targets if available, otherwise use app's default goals
   const targets = {
@@ -51,17 +53,14 @@ export default function NutritionDashboard({
     if (typeof window !== 'undefined') {
       const today = new Date().toISOString().split('T')[0];
       const lastDay = localStorage.getItem('last-active-day');
-      
+
       if (!lastDay || lastDay !== today) {
         localStorage.setItem('last-active-day', today);
         // Refresh data when a new day is detected using React Query invalidation
         const refreshData = async () => {
           try {
-            const { queryClient } = await import('@/providers/QueryProvider');
-            if (queryClient) {
-              queryClient.invalidateQueries({ queryKey: ['meals'] });
-              queryClient.invalidateQueries({ queryKey: ['user'] });
-            }
+            queryClient.invalidateQueries({ queryKey: ['meals'] });
+            queryClient.invalidateQueries({ queryKey: ['user'] });
           } catch (error) {
             console.error('Failed to refresh data:', error);
           }
@@ -69,7 +68,7 @@ export default function NutritionDashboard({
         refreshData();
       }
     }
-  }, []);
+  }, [queryClient]);
 
   return (
     <Card>

--- a/src/hooks/useAnalyzeImage.ts
+++ b/src/hooks/useAnalyzeImage.ts
@@ -25,7 +25,7 @@ class ApiError extends Error {
 
 export function useAnalyzeImage() {
   const { user } = useAuth();
-  const { addMeal: addMealToSupabase } = useMeals();
+  const { addMeal: addMealToSupabase } = useMeals(undefined, { skip: true });
   const refreshAll = useAppStore((state) => state.refreshAll);
   const queryClient = useQueryClient();
   
@@ -114,11 +114,7 @@ export function useAnalyzeImage() {
           if (mealSaved) {
             // Invalidate React Query cache to refresh meals list
             // Properly invalidate all related queries
-            queryClient.invalidateQueries({ queryKey: ['meals'] });
-            
-            // Directly fetch a fresh copy instead of waiting for automatic refetch
-            queryClient.fetchQuery({ queryKey: ['meals', user.id] })
-              .catch(error => console.error('Error fetching updated meals:', error));
+            queryClient.invalidateQueries({ queryKey: ['meals', user.id] });
             
             // Also refresh app store state as a fallback
             try {

--- a/src/hooks/useMeals.ts
+++ b/src/hooks/useMeals.ts
@@ -1,203 +1,171 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { supabase } from '@/lib/supabase-client';
 import type { Meal } from '@/lib/supabase-client';
 import { useAuth } from './useAuth';
-import { getStartOfDayGmt8 } from '@/lib/utils';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
-export function useMeals() {
+interface UseMealsOptions {
+  skip?: boolean;
+}
+
+const getDateKey = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export function useMeals(selectedDate?: Date, options?: UseMealsOptions) {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  
-  // Define query function
+  const skip = options?.skip ?? false;
+  const userId = user?.id;
+  const selectedDateTime = selectedDate?.getTime();
+
+  const dateInfo = useMemo(() => {
+    const base = selectedDateTime ? new Date(selectedDateTime) : new Date();
+    const start = new Date(base);
+    start.setHours(0, 0, 0, 0);
+
+    const end = new Date(base);
+    end.setHours(23, 59, 59, 999);
+
+    return {
+      start,
+      end,
+      key: getDateKey(start),
+    };
+  }, [selectedDateTime]);
+
   const fetchMeals = useCallback(async () => {
-    console.log('[useMeals] fetchMeals called. User ID:', user?.id); // Added log
-    if (!user) {
-      return {
-        allMeals: [],
-        todayMeals: []
-      };
+    if (!userId) {
+      return [] as Meal[];
     }
-    
-    try {
-      // Get the start of the current day
-      getStartOfDayGmt8(); // For timezone calculation
-      
-      console.log('Fetching meals for user:', user.id);
-      
-      // Fetch all meals for this user
-      const { data, error } = await supabase
-        .from('meals')
-        .select('*')
-        .eq('user_id', user.id)
-        .order('created_at', { ascending: false });
-        
-      if (error) {
-        console.error('Error in Supabase query:', error);
-        throw error;
-      }
-      
-      if (data) {
-        console.log(`Retrieved ${data.length} meals from Supabase`);
-        const allMeals = data as Meal[];
-        
-        // Filter for today's meals using start and end of day timestamps
-        const now = new Date();
-        const startOfDay = new Date(now);
-        startOfDay.setHours(0, 0, 0, 0);
-        
-        const endOfDay = new Date(now);
-        endOfDay.setHours(23, 59, 59, 999);
-        
-        const today = allMeals.filter(meal => {
-          const mealDate = new Date(meal.created_at);
-          const isInToday = mealDate >= startOfDay && mealDate <= endOfDay;
-          console.log(`Checking meal: ${meal.meal_name}, date: ${mealDate.toISOString()}, isInToday: ${isInToday}`);
-          return isInToday;
-        });
-        console.log(`Found ${today.length} meals for today`);
-        
-        return {
-          allMeals,
-          todayMeals: today
-        };
-      } else {
-        console.log('No meals found for user');
-        return {
-          allMeals: [],
-          todayMeals: []
-        };
-      }
-    } catch (err) {
-      console.error('Error fetching meals:', err);
-      throw err;
+
+    const { data, error } = await supabase
+      .from('meals')
+      .select('id, user_id, meal_name, ingredients, calories, protein, carbs, fat, created_at, image_url')
+      .eq('user_id', userId)
+      .gte('created_at', dateInfo.start.toISOString())
+      .lte('created_at', dateInfo.end.toISOString())
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      throw error;
     }
-  }, [user]);
-  
-  // Create React Query for meals with reasonable staleTime
-  const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ['meals', user?.id],
+
+    return (data ?? []) as Meal[];
+  }, [userId, dateInfo]);
+
+  const {
+    data: mealsForDay = [],
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['meals', userId, dateInfo.key],
     queryFn: fetchMeals,
-    enabled: !!user,
-    staleTime: 30000, // 30 seconds - prevent excessive refetching
-    refetchOnMount: 'always', // Always refetch on mount
-    refetchOnWindowFocus: false, // Don't refetch on window focus to reduce API calls
-    refetchInterval: false, // Disable polling - rely on invalidation after mutations
-    retry: 2, // Retry failed queries twice
+    enabled: !!userId && !skip,
+    staleTime: 60000,
+    refetchOnWindowFocus: false,
+    retry: 2,
   });
-  
-  // Extract meals from query data or use empty arrays as fallback
-  const meals = data?.allMeals || [];
-  const todayMeals = data?.todayMeals || [];
+
+  const dailyTotals = useMemo(() => {
+    return mealsForDay.reduce(
+      (acc, meal) => ({
+        calories: acc.calories + (meal.calories || 0),
+        protein: acc.protein + (meal.protein || 0),
+        carbs: acc.carbs + (meal.carbs || 0),
+        fat: acc.fat + (meal.fat || 0),
+      }),
+      { calories: 0, protein: 0, carbs: 0, fat: 0 },
+    );
+  }, [mealsForDay]);
 
   const addMeal = useCallback(async (mealData: Omit<Meal, 'id' | 'user_id' | 'created_at'>) => {
-    if (!user) {
+    if (!userId) {
       throw new Error('User not authenticated');
     }
-    
+
     try {
-      console.log('Adding meal to Supabase for user:', user.id);
-      
       const newMeal = {
         ...mealData,
-        user_id: user.id,
+        user_id: userId,
       };
-      
-      console.log('Meal data to insert:', newMeal);
-      
+
       const { data, error } = await supabase
         .from('meals')
         .insert([newMeal])
         .select()
         .single();
-        
+
       if (error) {
-        console.error('Error inserting meal into Supabase:', error);
         throw error;
       }
-      
-      console.log('Meal added successfully, invalidating query cache for key:', ['meals', user?.id]); // Updated log
-      // Invalidate queries to trigger a refresh
-      queryClient.invalidateQueries({ queryKey: ['meals', user?.id] }); // Made invalidation specific
-      
+
+      queryClient.invalidateQueries({ queryKey: ['meals', userId] });
+
       return data as Meal;
     } catch (err) {
-      console.error('Error adding meal:', err);
       throw err;
     }
-  }, [user, queryClient]);
+  }, [userId, queryClient]);
 
   const updateMeal = useCallback(async (mealId: string, updates: Partial<Meal>) => {
-    if (!user) {
+    if (!userId) {
       throw new Error('User not authenticated');
     }
-    
+
     try {
       const { data, error } = await supabase
         .from('meals')
         .update(updates)
         .eq('id', mealId)
-        .eq('user_id', user.id) // Ensure the meal belongs to this user
+        .eq('user_id', userId) // Ensure the meal belongs to this user
         .select()
         .single();
-        
+
       if (error) {
         throw error;
       }
-      
-      console.log('Meal updated successfully, invalidating query cache for key:', ['meals', user?.id]); // Added log
-      // Invalidate queries to trigger a refresh
-      queryClient.invalidateQueries({ queryKey: ['meals', user?.id] }); // Made invalidation specific
-      
+
+      queryClient.invalidateQueries({ queryKey: ['meals', userId] });
+
       return data as Meal;
     } catch (err) {
-      console.error('Error updating meal:', err);
       throw err;
     }
-  }, [user, queryClient]);
+  }, [userId, queryClient]);
 
   const deleteMeal = useCallback(async (mealId: string) => {
-    if (!user) {
+    if (!userId) {
       throw new Error('User not authenticated');
     }
-    
+
     try {
       const { error } = await supabase
         .from('meals')
         .delete()
         .eq('id', mealId)
-        .eq('user_id', user.id); // Ensure the meal belongs to this user
-        
+        .eq('user_id', userId); // Ensure the meal belongs to this user
+
       if (error) {
         throw error;
       }
-      
-      console.log('Meal deleted successfully, invalidating query cache for key:', ['meals', user?.id]); // Added log
-      // Invalidate queries to trigger a refresh
-      queryClient.invalidateQueries({ queryKey: ['meals', user?.id] }); // Made invalidation specific
+
+      queryClient.invalidateQueries({ queryKey: ['meals', userId] });
     } catch (err) {
-      console.error('Error deleting meal:', err);
       throw err;
     }
-  }, [user, queryClient]);
-
-  // Calculate daily totals
-  const dailyTotals = todayMeals.reduce((acc, meal) => {
-    return {
-      calories: acc.calories + (meal.calories || 0),
-      protein: acc.protein + (meal.protein || 0),
-      carbs: acc.carbs + (meal.carbs || 0),
-      fat: acc.fat + (meal.fat || 0),
-    };
-  }, { calories: 0, protein: 0, carbs: 0, fat: 0 });
+  }, [userId, queryClient]);
 
   return {
-    meals,
-    todayMeals,
+    todayMeals: mealsForDay,
     dailyTotals,
-    loading: isLoading,
+    loading: !!userId && !skip ? isLoading : false,
     error,
     addMeal,
     updateMeal,


### PR DESCRIPTION
## Summary
- scope meal fetching to the active day and add a skip option in `useMeals` to avoid redundant queries
- update dashboard-related components to use the shared React Query client for cache invalidation
- simplify manual entry and description analyzers to rely on query invalidation instead of direct refetches

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68df497f72ac8327a3493cc9ad27bd90