### PR TITLE
fix: add support for non-integer nutrition values

### DIFF
--- a/src/components/app/ManualFoodEntry.tsx
+++ b/src/components/app/ManualFoodEntry.tsx
@@ -54,10 +54,10 @@ const ManualFoodEntry = memo(function ManualFoodEntry() {
       
       const mealData = {
         meal_name: mealName,
-        calories: parseInt(calories),
-        protein: parseInt(protein),
-        carbs: parseInt(carbs),
-        fat: parseInt(fat),
+        calories: parseFloat(calories),
+        protein: parseFloat(protein),
+        carbs: parseFloat(carbs),
+        fat: parseFloat(fat),
         ingredients: ingredientsArray,
       };
       
@@ -112,6 +112,7 @@ const ManualFoodEntry = memo(function ManualFoodEntry() {
               <Input
                 id="calories"
                 type="number"
+                step="0.1"
                 placeholder="e.g., 350"
                 value={calories}
                 onChange={(e) => setCalories(e.target.value)}
@@ -123,6 +124,7 @@ const ManualFoodEntry = memo(function ManualFoodEntry() {
               <Input
                 id="protein"
                 type="number"
+                step="0.1"
                 placeholder="e.g., 25"
                 value={protein}
                 onChange={(e) => setProtein(e.target.value)}
@@ -134,6 +136,7 @@ const ManualFoodEntry = memo(function ManualFoodEntry() {
               <Input
                 id="carbs"
                 type="number"
+                step="0.1"
                 placeholder="e.g., 30"
                 value={carbs}
                 onChange={(e) => setCarbs(e.target.value)}
@@ -145,6 +148,7 @@ const ManualFoodEntry = memo(function ManualFoodEntry() {
               <Input
                 id="fat"
                 type="number"
+                step="0.1"
                 placeholder="e.g., 15"
                 value={fat}
                 onChange={(e) => setFat(e.target.value)}

--- a/src/components/app/MealEditForm.tsx
+++ b/src/components/app/MealEditForm.tsx
@@ -98,38 +98,42 @@ export default function MealEditForm({ meal, onCancel, onSave, onAiUpdate }: Mea
             <label className="text-xs text-muted-foreground mb-1 block">Calories</label>
             <Input
               type="number"
+              step="0.1"
               value={calories}
-              onChange={(e) => setCalories(Math.max(0, parseInt(e.target.value) || 0))}
+              onChange={(e) => setCalories(Math.max(0, parseFloat(e.target.value) || 0))}
               className="w-full px-2 py-1 text-sm rounded border bg-background"
             />
           </div>
-          
+
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">Protein (g)</label>
             <Input
               type="number"
+              step="0.1"
               value={protein}
-              onChange={(e) => setProtein(Math.max(0, parseInt(e.target.value) || 0))}
+              onChange={(e) => setProtein(Math.max(0, parseFloat(e.target.value) || 0))}
               className="w-full px-2 py-1 text-sm rounded border bg-background"
             />
           </div>
-          
+
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">Carbs (g)</label>
             <Input
               type="number"
+              step="0.1"
               value={carbs}
-              onChange={(e) => setCarbs(Math.max(0, parseInt(e.target.value) || 0))}
+              onChange={(e) => setCarbs(Math.max(0, parseFloat(e.target.value) || 0))}
               className="w-full px-2 py-1 text-sm rounded border bg-background"
             />
           </div>
-          
+
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">Fat (g)</label>
             <Input
               type="number"
+              step="0.1"
               value={fat}
-              onChange={(e) => setFat(Math.max(0, parseInt(e.target.value) || 0))}
+              onChange={(e) => setFat(Math.max(0, parseFloat(e.target.value) || 0))}
               className="w-full px-2 py-1 text-sm rounded border bg-background"
             />
           </div>

--- a/src/components/app/MealHistory.tsx
+++ b/src/components/app/MealHistory.tsx
@@ -112,38 +112,42 @@ const MealEditForm = memo<MealEditFormProps>(({ meal, onCancel, onSave, onAiUpda
             <label className="text-xs text-muted-foreground mb-1 block">Calories</label>
             <input
               type="number"
+              step="0.1"
               value={calories}
-              onChange={(e) => setCalories(Math.max(0, parseInt(e.target.value) || 0))}
+              onChange={(e) => setCalories(Math.max(0, parseFloat(e.target.value) || 0))}
               className="w-full px-2 py-1 text-sm rounded border bg-background"
             />
           </div>
-          
+
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">Protein (g)</label>
             <input
               type="number"
+              step="0.1"
               value={protein}
-              onChange={(e) => setProtein(Math.max(0, parseInt(e.target.value) || 0))}
+              onChange={(e) => setProtein(Math.max(0, parseFloat(e.target.value) || 0))}
               className="w-full px-2 py-1 text-sm rounded border bg-background"
             />
           </div>
-          
+
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">Carbs (g)</label>
             <input
               type="number"
+              step="0.1"
               value={carbs}
-              onChange={(e) => setCarbs(Math.max(0, parseInt(e.target.value) || 0))}
+              onChange={(e) => setCarbs(Math.max(0, parseFloat(e.target.value) || 0))}
               className="w-full px-2 py-1 text-sm rounded border bg-background"
             />
           </div>
-          
+
           <div>
             <label className="text-xs text-muted-foreground mb-1 block">Fat (g)</label>
             <input
               type="number"
+              step="0.1"
               value={fat}
-              onChange={(e) => setFat(Math.max(0, parseInt(e.target.value) || 0))}
+              onChange={(e) => setFat(Math.max(0, parseFloat(e.target.value) || 0))}
               className="w-full px-2 py-1 text-sm rounded border bg-background"
             />
           </div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -69,19 +69,19 @@ const parseNutritionResponse = (rawContent: string): NutritionInfo => {
 
   // Fallback logic (less likely to work for structured data like mealName/ingredients)
   try {
-    const caloriesMatch = originalRawResponse.match(/calories":?\s*(\d+)/i);
-    const proteinMatch = originalRawResponse.match(/protein":?\s*(\d+)/i);
-    const carbsMatch = originalRawResponse.match(/carbs":?\s*(\d+)/i);
-    const fatMatch = originalRawResponse.match(/fat":?\s*(\d+)/i);
+    const caloriesMatch = originalRawResponse.match(/calories":?\s*(\d+(?:\.\d+)?)/i);
+    const proteinMatch = originalRawResponse.match(/protein":?\s*(\d+(?:\.\d+)?)/i);
+    const carbsMatch = originalRawResponse.match(/carbs":?\s*(\d+(?:\.\d+)?)/i);
+    const fatMatch = originalRawResponse.match(/fat":?\s*(\d+(?:\.\d+)?)/i);
     // Basic fallback for mealName (less reliable)
     const mealNameMatch = originalRawResponse.match(/mealName":?\s*"([^"]+)"/i);
 
     if (caloriesMatch && proteinMatch && carbsMatch && fatMatch) {
       return {
-        calories: parseInt(caloriesMatch[1], 10),
-        protein: parseInt(proteinMatch[1], 10),
-        carbs: parseInt(carbsMatch[1], 10),
-        fat: parseInt(fatMatch[1], 10),
+        calories: parseFloat(caloriesMatch[1]),
+        protein: parseFloat(proteinMatch[1]),
+        carbs: parseFloat(carbsMatch[1]),
+        fat: parseFloat(fatMatch[1]),
         mealName: mealNameMatch ? mealNameMatch[1] : undefined, // Add extracted mealName if found
         // Ingredients fallback is too complex/unreliable via regex
         rawResponse: originalRawResponse,


### PR DESCRIPTION
This fixes the food detector to properly handle decimal/floating-point values for nutrition data. Previously, when a food had a value like 0.5 or 25.7, the app would break or lose precision.

Changes:
- Updated API regex patterns to match decimal values (e.g., 0.5, 25.7)
- Changed parseInt() to parseFloat() in all nutrition value parsing
- Added step="0.1" to number inputs to allow decimal entry
- Fixed ManualFoodEntry, MealEditForm, and MealHistory components

Files modified:
- src/services/api.ts: Updated regex from (\d+) to (\d+(?:\.\d+)?) and parseInt to parseFloat
- src/components/app/ManualFoodEntry.tsx: Changed parseInt to parseFloat and added step attribute
- src/components/app/MealEditForm.tsx: Changed parseInt to parseFloat and added step attribute
- src/components/app/MealHistory.tsx: Changed parseInt to parseFloat and added step attribute